### PR TITLE
Implementing primary-navbar Component

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/primarynavbar/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/primarynavbar/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="cq:Component"
+          jcr:title="primarynavbar"
+          componentGroup="Pitneybowes"
+          sling:resourceSuperType="core/wcm/components/navigation/v2/navigation"/>

--- a/ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/primarynavbar/primarynavbar.html
+++ b/ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/primarynavbar/primarynavbar.html
@@ -1,0 +1,39 @@
+
+<sly data-sly-use.nav="com.adobe.cq.wcm.core.components.models.Navigation">
+  <nav class="mega-nav">
+    <ul class="mega-nav__list">
+      <sly data-sly-list="${nav.items}">
+        <li class="mega-nav__item">
+          <a href="${item.URL}" class="mega-nav__link mega-nav__toggle">
+            ${item.title}
+          </a>
+ 
+          <!-- Mega Menu Dropdown -->
+          <sly data-sly-test="${item.children && item.children.size > 0}">
+            <div class="mega-nav__dropdown">
+              <div class="mega-nav__columns">
+                <sly data-sly-list.child="${item.children}">
+                  <div class="mega-nav__column">
+                    <h4 class="mega-nav__heading">
+                      <a href="${child.URL}">${child.title}</a>
+                    </h4>
+                    <div class="mega-nav__underline"></div>
+                    <ul class="mega-nav__sublist">
+                      <sly data-sly-list.sub="${child.children}">
+                        <li>
+                          <a href="${sub.URL}" class="mega-nav__sublink">${sub.title}</a>
+                        </li>
+                      </sly>
+                    </ul>
+                  </div>
+                </sly>
+              </div>
+            </div>
+          </sly>
+        </li>
+      </sly>
+    </ul>
+  </nav>
+</sly>
+ 
+ 


### PR DESCRIPTION
### Description

This feature introduces a Primary Navigation Bar component in AEM under
/apps/pitneybowes/components/primarynavbar.

### Purpose:

Provides a reusable navigation bar UI element for Pitney Bowes site pages.

Helps users easily navigate across the main sections of the site.
### Files Added
> ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/primarynavbar/.content.xml
> ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/primarynavbar/primarynavbar.html> 
