### PR TITLE
feature_tile component

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/feature_tile/feature_tile.html
+++ b/ui.apps/src/main/content/jcr_root/apps/pitneybowes/components/feature_tile/feature_tile.html
@@ -1,24 +1,40 @@
 <sly data-sly-use.model="com.aem.pitneybowes.core.models.Feature_tileModel"/>
 <sly data-sly-use.placeholderTemplate="core/wcm/components/commons/v1/templates.html"/>
 <sly data-sly-test.hasContent="${!model.empty}">
-  <sly data-sly-test="${model.maintitle}">
-    <p>Main_title: ${model.maintitle}</p>
-  </sly>
-  <sly data-sly-test="${model.multi && model.multi.size > 0}">
-    <ul data-sly-list.item="${model.multi}">
-      <sly data-sly-test="${item.image}">
-        <p>Image: <img src="${item.image}" alt="Image" style="max-width:100%; height:auto;"/></p>
-      </sly>
-      <sly data-sly-test="${item.subtitle}">
-        <p>Sub_title: ${item.subtitle}</p>
-      </sly>
-      <sly data-sly-test="${item.linkpath}">
-        <p>Link_path: <a href="${item.linkpath}">${item.linkpath}</a></p>
-      </sly>
-      <sly data-sly-test="${item.paragraph}">
-        <p>Paragraph: ${item.paragraph @ context='html'}</p>
-      </sly>
-    </ul>
-  </sly>
+
+  <section class="feature-section">
+    <sly data-sly-test="${model.multi && model.multi.size > 0}">
+      <div class="feature-grid" data-sly-list.item="${model.multi}">
+
+        <div class="feature-card">
+          
+          <!-- Icon Left -->
+          <sly data-sly-test="${item.image}">
+            <div class="feature-icon">
+              <img src="${item.image}" alt="icon"/>
+            </div>
+          </sly>
+
+          <!-- Text Right -->
+          <sly data-sly-test="${item.subtitle || item.paragraph}">
+            <div class="feature-content">
+              <sly data-sly-test="${item.subtitle}">
+                <h3 class="feature-title">
+                  <a href="${item.linkpath}">${item.subtitle}</a>
+                </h3>
+              </sly>
+
+              <sly data-sly-test="${item.paragraph}">
+                <p class="feature-text">${item.paragraph @ context='html'}</p>
+              </sly>
+            </div>
+          </sly>
+        </div>
+
+      </div>
+    </sly>
+  </section>
+
 </sly>
+
 <sly data-sly-call="${placeholderTemplate.placeholder @ isEmpty = !hasContent}" />

--- a/ui.frontend/src/main/webpack/components/_feature-tile.scss
+++ b/ui.frontend/src/main/webpack/components/_feature-tile.scss
@@ -1,0 +1,96 @@
+/* Section background (boxed, not full width) */
+.feature-section {
+  background: linear-gradient(90deg, #2a3d99, #9b1d82);
+  padding: 0rem;
+  border-radius: 8px;
+  color: #fff;
+  max-width: 88pc;   /* keeps it boxed */
+  margin: 0 auto;      /* centers with left/right whitespace */
+}
+
+/* Grid layout */
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr); /* 4 equal columns */
+  gap: 1.5rem;
+}
+
+/* Each card */
+.feature-card {
+  display: flex;
+  flex-direction: row;   /* icon left, text right */
+  align-items: center;   /* vertically align icon + text */
+  text-align: left;
+  padding: .1rem 1rem;  /* inner spacing */
+  position: relative;
+}
+
+/* Icon */
+.feature-icon {
+  flex-shrink: 0;       /* prevent icon shrinking */
+  margin-right: 1rem;   /* GAP between icon and text */
+}
+
+.feature-icon img {
+  width: 40px;
+  height: 40px;
+  display: block;
+}
+
+/* Text block inside card */
+.feature-content {
+  flex: 1; /* take remaining space */
+}
+
+/* Vertical divider */
+.feature-card:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  top: 20%;
+  right: 0;
+  width: 1px;
+  height: 60%;
+  background-color: rgba(255, 255, 255, 0.4);
+}
+
+/* Title */
+.feature-title {
+  font-size: 1.2rem;
+  font-weight: 300;
+  margin-bottom: -10px;
+}
+
+.feature-title a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+.feature-title a:hover {
+  text-decoration: underline;
+  text-decoration-thickness: 3px;   
+}
+
+/* Description */
+.feature-text {
+  font-size: 16px;
+  line-height: 1.4;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+/* Responsive tweaks */
+@media (max-width: 992px) {
+  .feature-grid {
+    grid-template-columns: 1fr 1fr; /* 2 per row */
+  }
+
+  .feature-card:not(:last-child)::after {
+    display: none; /* remove divider on small screens */
+  }
+}
+
+@media (max-width: 600px) {
+  .feature-grid {
+    grid-template-columns: 1fr; /* 1 per row */
+  }
+}


### PR DESCRIPTION
Added Feature_tile component using HTL/Sightly.

Dynamically renders multiple feature cards with optional icon, title (linked), and description.

Conditional rendering for elements: only shows icon if image exists, title if subtitle exists, and paragraph if paragraph exists.

Integrated placeholderTemplate for fallback content.

Styled section with boxed gradient background, rounded corners, and white text.

Grid layout for 4 columns on desktop, 2 on tablets, and 1 on mobile screens.

Each feature card has a left-aligned icon, right-aligned text, and vertical divider (hidden on smaller screens).

Responsive typography and spacing, with hover effects on links.